### PR TITLE
Add Elementor pricing calculator widget

### DIFF
--- a/grey-mirror-pricing-widget/gm-pricing-widget.php
+++ b/grey-mirror-pricing-widget/gm-pricing-widget.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Grey Mirror Pricing Calculator
 Description: Elementor widget for Grey Mirror pricing calculator.
-Version: 0.1.0
+Version: 0.1.1
 */
 
 if (!defined('ABSPATH')) {
@@ -10,7 +10,7 @@ if (!defined('ABSPATH')) {
 }
 
 class GM_Pricing_Plugin {
-    const VERSION = '0.1.0';
+    const VERSION = '0.1.1';
     public function __construct() {
         add_action('elementor/widgets/register', [$this, 'register_widget']);
         add_action('wp_enqueue_scripts', [$this, 'enqueue']);

--- a/grey-mirror-pricing-widget/gm-pricing-widget.php
+++ b/grey-mirror-pricing-widget/gm-pricing-widget.php
@@ -24,6 +24,8 @@ class GM_Pricing_Plugin {
     public function enqueue() {
         wp_register_script('gm-pricing-widget', plugins_url('widget.js', __FILE__), ['jquery'], self::VERSION, true);
         wp_enqueue_script('gm-pricing-widget');
+        wp_register_style('gm-pricing-widget', plugins_url('style.css', __FILE__), [], self::VERSION);
+        wp_enqueue_style('gm-pricing-widget');
     }
 }
 new GM_Pricing_Plugin();

--- a/grey-mirror-pricing-widget/gm-pricing-widget.php
+++ b/grey-mirror-pricing-widget/gm-pricing-widget.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Grey Mirror Pricing Calculator
 Description: Elementor widget for Grey Mirror pricing calculator.
-Version: 0.1.1
+Version: 0.2.0
 */
 
 if (!defined('ABSPATH')) {
@@ -10,7 +10,7 @@ if (!defined('ABSPATH')) {
 }
 
 class GM_Pricing_Plugin {
-    const VERSION = '0.1.1';
+    const VERSION = '0.2.0';
     public function __construct() {
         add_action('elementor/widgets/register', [$this, 'register_widget']);
         add_action('wp_enqueue_scripts', [$this, 'enqueue']);

--- a/grey-mirror-pricing-widget/gm-pricing-widget.php
+++ b/grey-mirror-pricing-widget/gm-pricing-widget.php
@@ -1,0 +1,29 @@
+<?php
+/*
+Plugin Name: Grey Mirror Pricing Calculator
+Description: Elementor widget for Grey Mirror pricing calculator.
+Version: 0.1.0
+*/
+
+if (!defined('ABSPATH')) {
+    exit; // Exit if accessed directly
+}
+
+class GM_Pricing_Plugin {
+    const VERSION = '0.1.0';
+    public function __construct() {
+        add_action('elementor/widgets/register', [$this, 'register_widget']);
+        add_action('wp_enqueue_scripts', [$this, 'enqueue']);
+    }
+
+    public function register_widget($widgets_manager) {
+        require_once __DIR__ . '/widget.php';
+        $widgets_manager->register(new GM_Pricing_Widget());
+    }
+
+    public function enqueue() {
+        wp_register_script('gm-pricing-widget', plugins_url('widget.js', __FILE__), ['jquery'], self::VERSION, true);
+        wp_enqueue_script('gm-pricing-widget');
+    }
+}
+new GM_Pricing_Plugin();

--- a/grey-mirror-pricing-widget/style.css
+++ b/grey-mirror-pricing-widget/style.css
@@ -1,0 +1,10 @@
+.gm-widget{background:#fff;border-radius:8px;padding:20px;box-shadow:0 0 10px rgba(218,165,32,0.3);transition:box-shadow .3s,transform .3s;max-width:400px;margin:auto}
+.gm-widget:hover{box-shadow:0 0 15px rgba(218,165,32,0.6);transform:translateY(-2px)}
+.gm-question{font-weight:600;margin-bottom:10px}
+.gm-options button{margin:5px}
+.gm-months{display:flex;justify-content:space-between;margin-top:10px}
+.gm-month{background:#fafafa;padding:10px;border-radius:4px;position:relative;flex:1;margin:5px;cursor:pointer;transition:background .3s}
+.gm-month:hover{background:#fffbe6}
+.gm-month-details{display:none;position:absolute;top:100%;left:0;background:#fff;border:1px solid #ccc;padding:5px;border-radius:4px;z-index:10;width:100%}
+.gm-month:hover .gm-month-details{display:block}
+@media(max-width:600px){.gm-widget{max-width:100%}}

--- a/grey-mirror-pricing-widget/style.css
+++ b/grey-mirror-pricing-widget/style.css
@@ -1,10 +1,72 @@
-.gm-widget{background:#fff;border-radius:8px;padding:20px;box-shadow:0 0 10px rgba(218,165,32,0.3);transition:box-shadow .3s,transform .3s;max-width:400px;margin:auto}
-.gm-widget:hover{box-shadow:0 0 15px rgba(218,165,32,0.6);transform:translateY(-2px)}
+.gm-widget{
+    font-family:var(--e-global-typography-primary-font-family);
+    color:var(--e-global-color-text);
+    background:#fff;
+    border-radius:12px;
+    padding:24px;
+    box-shadow:0 4px 12px rgba(218,165,32,0.2);
+    transition:box-shadow .3s,transform .3s;
+    max-width:480px;
+    margin:20px auto;
+}
+.gm-widget:hover{
+    box-shadow:0 6px 16px rgba(218,165,32,0.5);
+    transform:translateY(-4px);
+}
+.gm-flow-select label{margin-right:15px;font-weight:600}
 .gm-question{font-weight:600;margin-bottom:10px}
-.gm-options button{margin:5px}
-.gm-months{display:flex;justify-content:space-between;margin-top:10px}
-.gm-month{background:#fafafa;padding:10px;border-radius:4px;position:relative;flex:1;margin:5px;cursor:pointer;transition:background .3s}
+.gm-options button,
+.gm-manual-next,
+.gm-calc{
+    background:var(--e-global-color-primary);
+    color:#fff;
+    border:none;
+    padding:8px 12px;
+    border-radius:4px;
+    margin:5px;
+    cursor:pointer;
+    font-family:inherit;
+    transition:background .3s;
+}
+.gm-options button:hover,
+.gm-manual-next:hover,
+.gm-calc:hover{
+    background:var(--e-global-color-primary-hover,#333);
+}
+.gm-months{
+    display:grid;
+    grid-template-columns:repeat(auto-fit,minmax(80px,1fr));
+    gap:8px;
+    margin-top:20px;
+}
+.gm-month{
+    background:#fafafa;
+    padding:10px;
+    border-radius:8px;
+    position:relative;
+    text-align:center;
+    cursor:pointer;
+    transition:background .3s;
+}
 .gm-month:hover{background:#fffbe6}
-.gm-month-details{display:none;position:absolute;top:100%;left:0;background:#fff;border:1px solid #ccc;padding:5px;border-radius:4px;z-index:10;width:100%}
+.gm-month-details{
+    display:none;
+    position:absolute;
+    top:100%;
+    left:0;
+    right:0;
+    background:#fff;
+    box-shadow:0 2px 6px rgba(0,0,0,0.1);
+    padding:10px;
+    border-radius:8px;
+    z-index:20;
+    text-align:left;
+}
 .gm-month:hover .gm-month-details{display:block}
-@media(max-width:600px){.gm-widget{max-width:100%}}
+@media(max-width:600px){
+    .gm-widget{max-width:100%;padding:16px;}
+}
+.gm-service-item{
+    display:block;
+    margin-bottom:6px;
+}

--- a/grey-mirror-pricing-widget/style.css
+++ b/grey-mirror-pricing-widget/style.css
@@ -39,6 +39,19 @@
 .gm-pill:active{transform:scale(.97);}
 .gm-pill input{display:none;}
 .gm-pill input:checked+span{background:#0d90ff;color:#fff;border-color:#0d90ff;}
+.gm-select select{
+    -webkit-appearance:none;
+    -moz-appearance:none;
+    appearance:none;
+    padding:.6rem 1rem;
+    border:1px solid rgba(0,0,0,.2);
+    border-radius:9999px;
+    font-weight:500;
+    width:100%;
+    background:rgba(255,255,255,.08) url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23000' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E") no-repeat right .75rem center/12px;
+    cursor:pointer;
+}
+.gm-select select:focus{outline:none;box-shadow:0 0 0 3px rgba(13,144,255,.3);}
 .gm-nav{display:flex;justify-content:space-between;margin-top:1rem;gap:1rem;}
 .gm-nav button{min-width:140px;height:48px;border-radius:9999px;border:1px solid rgba(0,0,0,.2);background:transparent;cursor:pointer;font-weight:500;transition:background .15s,transform .15s;}
 .gm-nav button:hover{background:rgba(13,144,255,.1);}

--- a/grey-mirror-pricing-widget/style.css
+++ b/grey-mirror-pricing-widget/style.css
@@ -1,72 +1,58 @@
-.gm-widget{
+.gm-wrapper{
+    display:flex;
+    flex-direction:column;
+    gap:2rem;
+    padding-inline:clamp(1rem,5vw,3rem);
+    align-items:center;
+}
+@media(min-width:1024px){
+    .gm-wrapper{flex-direction:row;gap:4rem;}
+}
+.gm-card{
+    --card-bg:rgba(255,255,255,.18);
+    --card-blur:blur(18px);
+    --card-border:1px solid rgba(255,255,255,.3);
     font-family:var(--e-global-typography-primary-font-family);
     color:var(--e-global-color-text);
-    background:#fff;
-    border-radius:12px;
-    padding:24px;
-    box-shadow:0 4px 12px rgba(218,165,32,0.2);
-    transition:box-shadow .3s,transform .3s;
-    max-width:480px;
-    margin:20px auto;
+    background:var(--card-bg);
+    backdrop-filter:var(--card-blur);
+    border:var(--card-border);
+    border-radius:24px;
+    box-shadow:0 8px 24px rgba(0,0,0,.15);
+    padding:2rem 2.25rem;
+    isolation:isolate;
+    z-index:10;
+    width:100%;
+    max-width:min(420px,32vw);
 }
-.gm-widget:hover{
-    box-shadow:0 6px 16px rgba(218,165,32,0.5);
-    transform:translateY(-4px);
+@media(max-width:1023px){
+    .gm-card{max-width:360px;}
 }
-.gm-flow-select label{margin-right:15px;font-weight:600}
-.gm-question{font-weight:600;margin-bottom:10px}
-.gm-options button,
-.gm-manual-next,
-.gm-calc{
-    background:var(--e-global-color-primary);
-    color:#fff;
-    border:none;
-    padding:8px 12px;
-    border-radius:4px;
-    margin:5px;
-    cursor:pointer;
-    font-family:inherit;
-    transition:background .3s;
-}
-.gm-options button:hover,
-.gm-manual-next:hover,
-.gm-calc:hover{
-    background:var(--e-global-color-primary-hover,#333);
-}
-.gm-months{
-    display:grid;
-    grid-template-columns:repeat(auto-fit,minmax(80px,1fr));
-    gap:8px;
-    margin-top:20px;
-}
-.gm-month{
-    background:#fafafa;
-    padding:10px;
-    border-radius:8px;
-    position:relative;
-    text-align:center;
-    cursor:pointer;
-    transition:background .3s;
-}
-.gm-month:hover{background:#fffbe6}
-.gm-month-details{
-    display:none;
-    position:absolute;
-    top:100%;
-    left:0;
-    right:0;
-    background:#fff;
-    box-shadow:0 2px 6px rgba(0,0,0,0.1);
-    padding:10px;
-    border-radius:8px;
-    z-index:20;
-    text-align:left;
-}
-.gm-month:hover .gm-month-details{display:block}
-@media(max-width:600px){
-    .gm-widget{max-width:100%;padding:16px;}
-}
-.gm-service-item{
-    display:block;
-    margin-bottom:6px;
-}
+.gm-progress{position:relative;height:2px;width:100%;background:rgba(255,255,255,.2);border-top-left-radius:inherit;border-top-right-radius:inherit;overflow:hidden;margin-bottom:1rem;}
+.gm-progress-bar{position:absolute;height:100%;width:0;background:linear-gradient(90deg,#0d90ff 0%,#7fd5ff 100%);transition:width .3s cubic-bezier(.4,0,.2,1);}
+.gm-flow-select{display:flex;gap:1rem;margin-bottom:1rem;}
+.gm-flow-select label{font-weight:600;cursor:pointer;}
+.gm-question{font-weight:600;font-size:18px;margin-bottom:.5rem;}
+.gm-options{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:12px;margin-bottom:1rem;}
+.gm-pill{display:inline-flex;align-items:center;justify-content:center;padding:.6rem 1rem;border-radius:9999px;font-weight:500;border:1px solid rgba(0,0,0,.2);cursor:pointer;transition:background .15s,transform .15s;}
+.gm-pill:hover{box-shadow:inset 0 0 0 2px rgba(255,255,255,.2);}
+.gm-pill:active{transform:scale(.97);}
+.gm-pill input{display:none;}
+.gm-pill input:checked+span{background:#0d90ff;color:#fff;border-color:#0d90ff;}
+.gm-nav{display:flex;justify-content:space-between;margin-top:1rem;gap:1rem;}
+.gm-nav button{min-width:140px;height:48px;border-radius:9999px;border:1px solid rgba(0,0,0,.2);background:transparent;cursor:pointer;font-weight:500;transition:background .15s,transform .15s;}
+.gm-nav button:hover{background:rgba(13,144,255,.1);}
+.gm-nav .gm-next{background:#0d90ff;color:#fff;border:none;}
+.gm-nav .gm-next:hover{background:#0b7de8;}
+.gm-nav .gm-next svg{margin-left:.5rem;transition:transform .15s;}
+.gm-nav .gm-next:hover svg{transform:translateX(4px);}
+.gm-months{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:12px;margin-top:1rem;}
+.gm-month{background:rgba(255,255,255,.12);backdrop-filter:blur(10px);border-radius:16px;padding:1rem;text-align:center;cursor:pointer;position:relative;transition:background .3s;}
+.gm-month:hover{background:rgba(255,255,255,.22);}
+.gm-month .gm-total{font-size:32px;font-weight:700;letter-spacing:-0.015em;}
+.gm-month .gm-label{text-transform:uppercase;font-size:6px;letter-spacing:.05em;opacity:.7;margin-bottom:.25rem;}
+.gm-month-details{overflow:hidden;max-height:0;transition:max-height .25s ease;text-align:left;margin-top:.5rem;font-size:14px;}
+.gm-month.open .gm-month-details{max-height:300px;}
+.gm-cta{width:100%;height:48px;border-radius:9999px;background:#0d90ff;color:#fff;font-weight:600;letter-spacing:.025em;border:none;margin-top:1rem;cursor:pointer;transition:background .15s;}
+.gm-cta:hover{background:#0b7de8;}
+.gm-service-item{display:block;margin-bottom:6px;}

--- a/grey-mirror-pricing-widget/widget.js
+++ b/grey-mirror-pricing-widget/widget.js
@@ -1,0 +1,198 @@
+(function($){
+    const services = {
+        'gbp_opt': {name:'GBP Optimization', pillar:'local', dep:[], discountable:true, loc:true, base:[600,0,0], monthly:300},
+        'cit_base': {name:'Citation Building (Base)', pillar:'local', dep:[], discountable:true, loc:true, base:[200,0,0], monthly:100},
+        'cit_plus': {name:'Citation Building (Plus)', pillar:'local', dep:['cit_base'], discountable:true, loc:true, base:[100,100,0], monthly:100},
+        'web_dev': {name:'Web Dev w/ SEO', pillar:'web', dep:[], discountable:true, loc:false, pages:true, base:[2500,0,0], monthly:150},
+        'backlink': {name:'Backlink Strategy', pillar:'web', dep:[], discountable:false, loc:false, base:[1000,1000,500], monthly:1500},
+        'review': {name:'Review Engineering', pillar:'conv', dep:[], discountable:true, loc:false, base:[300,0,0], monthly:200},
+        'calls': {name:'Calls for Review', pillar:'conv', dep:['review'], discountable:false, loc:false, base:[100,0,0], monthly:700},
+        'community': {name:'Community Seeding', pillar:'conv', dep:[], discountable:true, loc:false, base:[250,150,100], monthly:500},
+        'entity': {name:'Entity & Schema Alignment', pillar:'ai', dep:[], discountable:true, loc:false, base:[300,150,0], monthly:400},
+        'answers': {name:'Conversational Answer Eng.', pillar:'ai', dep:[], discountable:true, loc:false, base:[250,250,0], monthly:350},
+        'prompt': {name:'Prompt & Model Feedback', pillar:'ai', dep:[], discountable:true, loc:false, base:[250,250,0], monthly:300}
+    };
+
+    const questions = [
+        {text:'Do you want your practice to be the very first thing patients see on Google Maps and in near-me searches?', add:['gbp_opt','cit_base','cit_plus']},
+        {text:'Is your website outdated or failing to turn visitors into patients?', add:['web_dev']},
+        {text:'Do you need to boost your site\'s authority with quality backlinks?', add:['backlink']},
+        {text:'Are you struggling to consistently get fresh 5-star patient reviews?', add:['review']},
+        {text:'Would you go the extra mile by calling patients to get feedback and reviews?', add:['calls']},
+        {text:'Do you want to build buzz in local online communities around your practice?', add:['community']},
+        {text:'Do you want your practice to be visible in AI-driven search results and voice assistants?', add:['entity','answers','prompt']}
+    ];
+
+    function enforceDeps(selected){
+        if(selected.has('cit_plus')) selected.add('cit_base');
+        if(selected.has('calls')) selected.add('review');
+        if(!selected.has('review')) selected.delete('calls');
+        if(!selected.has('cit_base')) selected.delete('cit_plus');
+    }
+
+    function calcPrices(selected, locs, pages, discount){
+        const per50extra = Math.max(0, Math.ceil((pages-50)/50));
+        let result = {months:[0,0,0,0], breakdown:[{}, {}, {}, {}]};
+        selected.forEach(s => {
+            const svc = services[s];
+            const mult = svc.loc ? locs : 1;
+            let base = svc.base.slice();
+            if(s === 'web_dev' && pages>50){
+                base[0] += 1000*per50extra;
+            }
+            for(let i=0;i<3;i++){
+                const cost = base[i]*mult;
+                result.months[i]+=cost;
+                result.breakdown[i][svc.name]=cost;
+            }
+            const m = svc.monthly*mult;
+            result.months[3]+=m;
+            result.breakdown[3][svc.name]=m;
+        });
+        // apply discount
+        let factor = 1;
+        if(discount==='super') factor=0.85;
+        else if(discount==='dirt') factor=0.80;
+        else if(discount==='reverse') factor=1.20;
+        selected.forEach(s => {
+            const svc = services[s];
+            const allowed = (discount==='reverse') || (svc.discountable);
+            if(discount!=='none' && (discount==='reverse' || svc.discountable)){
+                for(let i=0;i<4;i++){
+                    let cost = result.breakdown[i][svc.name];
+                    if(typeof cost==='number'){
+                        if(discount==='reverse') cost*=1.2;
+                        else cost*= (svc.discountable ? (discount==='super'?0.85:0.80) : 1);
+                        result.breakdown[i][svc.name]=Math.round(cost);
+                    }
+                }
+            }
+        });
+        // recompute totals
+        result.months=[0,0,0,0];
+        for(let i=0;i<4;i++){
+            for(let k in result.breakdown[i]){
+                result.months[i]+=result.breakdown[i][k];
+            }
+        }
+        return result;
+    }
+
+    function summaryText(selected){
+        const map=new Map([
+            ['gbp_opt','improve your visibility on Google Maps'],
+            ['cit_base',''],['cit_plus',''],
+            ['web_dev','modernize your website to convert visitors'],
+            ['backlink','increase your search authority'],
+            ['review','generate more 5-star reviews'],
+            ['calls','personally reach out to patients for feedback'],
+            ['community','create buzz in local online communities'],
+            ['entity','stand out in AI search results'],
+            ['answers',''],['prompt','']
+        ]);
+        let parts=[];
+        selected.forEach(s=>{if(map.get(s)) parts.push(map.get(s));});
+        if(!parts.length) return '';
+        return 'You want to '+parts.join(', ') + '.';
+    }
+
+    $(function(){
+        const root = $('#gm-pricing-calculator');
+        const quiz = root.find('.gm-quiz');
+        const manual = root.find('.gm-manual');
+        const inputs = root.find('.gm-inputs');
+        const results = root.find('.gm-results');
+        const questionEl = quiz.find('.gm-question');
+        const selected = new Set();
+        let qIndex = 0;
+
+        function showQuestion(){
+            if(qIndex>=questions.length){
+                quiz.hide();
+                inputs.show();
+                return;
+            }
+            questionEl.text(questions[qIndex].text);
+        }
+        showQuestion();
+
+        quiz.find('.gm-yes').on('click', function(e){
+            e.preventDefault();
+            questions[qIndex].add.forEach(s=>selected.add(s));
+            qIndex++;
+            showQuestion();
+        });
+        quiz.find('.gm-no').on('click', function(e){
+            e.preventDefault();
+            qIndex++;
+            showQuestion();
+        });
+
+        root.find('input[name="gm_flow"]').on('change', function(){
+            if(this.value==='manual'){
+                quiz.hide();
+                manual.show();
+                inputs.hide();
+                results.hide();
+                buildManual();
+            } else {
+                quiz.show();
+                manual.hide();
+                inputs.hide();
+                results.hide();
+                qIndex=0; selected.clear();
+                showQuestion();
+            }
+        });
+
+        function buildManual(){
+            const form = manual.find('.gm-service-list');
+            form.empty();
+            for(let key in services){
+                const svc=services[key];
+                const label=$('<label></label>').text(' '+svc.name);
+                const chk=$('<input type="checkbox">').attr('value',key);
+                label.prepend(chk);
+                form.append(label).append('<br>');
+            }
+        }
+
+        manual.find('.gm-manual-next').on('click', function(e){
+            e.preventDefault();
+            selected.clear();
+            manual.find('input[type="checkbox"]:checked').each(function(){
+                selected.add(this.value);
+            });
+            enforceDeps(selected);
+            inputs.show();
+        });
+
+        root.find('.gm-calc').on('click', function(e){
+            e.preventDefault();
+            const locs = parseInt($('#gm-locations').val())||1;
+            const pages = parseInt($('#gm-pages').val())||50;
+            const discount = $('#gm-discount').val();
+            enforceDeps(selected);
+            const res = calcPrices(selected, locs, pages, discount);
+            const summary = summaryText(selected);
+            results.show();
+            results.find('.gm-summary').text('Summary: '+summary);
+            const table = $('<table></table>');
+            const header = $('<tr><th>Month</th><th>Total</th></tr>');
+            table.append(header);
+            ['1','2','3','4+'].forEach((m,i)=>{
+                const row=$('<tr></tr>');
+                row.append('<td>Month '+m+'</td>');
+                row.append('<td>$'+res.months[i].toFixed(0)+'</td>');
+                const breakdown = res.breakdown[i];
+                const details=$('<ul></ul>');
+                for(let k in breakdown){
+                    details.append('<li>'+k+': $'+breakdown[k].toFixed(0)+'</li>');
+                }
+                row.append($('<td></td>').append(details));
+                table.append(row);
+            });
+            results.find('.gm-table').empty().append(table);
+        });
+    });
+})(jQuery);

--- a/grey-mirror-pricing-widget/widget.js
+++ b/grey-mirror-pricing-widget/widget.js
@@ -63,13 +63,8 @@
             result.breakdown[3][svc.name]=m;
         });
         // apply discount
-        let factor = 1;
-        if(discount==='super') factor=0.85;
-        else if(discount==='dirt') factor=0.80;
-        else if(discount==='reverse') factor=1.20;
         selected.forEach(s => {
             const svc = services[s];
-            const allowed = (discount==='reverse') || (svc.discountable);
             if(discount!=='none' && (discount==='reverse' || svc.discountable)){
                 for(let i=0;i<4;i++){
                     let cost = result.breakdown[i][svc.name];
@@ -92,21 +87,29 @@
     }
 
     function summaryText(selected){
-        const map=new Map([
-            ['gbp_opt','improve your visibility on Google Maps'],
-            ['cit_base',''],['cit_plus',''],
-            ['web_dev','modernize your website to convert visitors'],
-            ['backlink','increase your search authority'],
-            ['review','generate more 5-star reviews'],
-            ['calls','personally reach out to patients for feedback'],
-            ['community','create buzz in local online communities'],
-            ['entity','stand out in AI search results'],
-            ['answers',''],['prompt','']
-        ]);
         let parts=[];
-        selected.forEach(s=>{if(map.get(s)) parts.push(map.get(s));});
-        if(!parts.length) return '';
-        return 'You want to '+parts.join(', ') + '.';
+        if(selected.has('gbp_opt')||selected.has('cit_base')||selected.has('cit_plus')){
+            parts.push('improve your visibility on Google Maps');
+        }
+        if(selected.has('web_dev')){
+            parts.push('modernize your website to convert visitors');
+        }
+        if(selected.has('backlink')){
+            parts.push('increase your search authority');
+        }
+        if(selected.has('review')||selected.has('calls')){
+            parts.push('generate more 5-star reviews');
+        }
+        if(selected.has('community')){
+            parts.push('create buzz in local online communities');
+        }
+        if(selected.has('entity')||selected.has('answers')||selected.has('prompt')){
+            parts.push('stand out in AI search results');
+        }
+        if(parts.length===0) return '';
+        if(parts.length===1) return 'You want to '+parts[0]+'.';
+        const last=parts.pop();
+        return 'You want to '+parts.join(', ')+', and '+last+'.';
     }
 
     $(function(){
@@ -182,10 +185,10 @@
             form.empty();
             for(let key in services){
                 const svc=services[key];
-                const label=$('<label></label>').text(' '+svc.name);
+                const row=$('<label class="gm-service-item"></label>').text(' '+svc.name);
                 const chk=$('<input type="checkbox">').attr('value',key);
-                label.prepend(chk);
-                form.append(label).append('<br>');
+                row.prepend(chk);
+                form.append(row);
             }
         }
 

--- a/grey-mirror-pricing-widget/widget.js
+++ b/grey-mirror-pricing-widget/widget.js
@@ -120,6 +120,8 @@
         const results = root.find('.gm-results');
         const questionEl = quiz.find('.gm-question');
         const optionsEl = quiz.find('.gm-options');
+        const progressBar = root.find('.gm-progress-bar');
+        const nav = quiz.find('.gm-nav');
         let questions = baseQuestions.slice();
         const selected = new Set();
         let qIndex = 0;
@@ -128,35 +130,43 @@
 
         function showQuestion(){
             if(qIndex>=questions.length){
+                progressBar.css('width','100%');
                 quiz.hide();
                 inputs.show();
                 return;
             }
+            progressBar.css('width', (qIndex/questions.length*100)+'%');
             const q = questions[qIndex];
             questionEl.text(q.text);
             optionsEl.empty();
             if(q.type==='options'){
                 q.options.forEach(opt=>{
-                    $('<button class="gm-choice"></button>').text(opt.t).appendTo(optionsEl).on('click',function(e){
+                    const label=$('<label class="gm-pill"></label>');
+                    const input=$('<input type="radio">').val(opt.v);
+                    const span=$('<span></span>').text(opt.t);
+                    label.append(input,span).appendTo(optionsEl).on('click',function(e){
                         e.preventDefault();
                         if(q.key==='locs') locs=opt.v;
                         if(q.key==='pages') pages=opt.v;
                         qIndex++; showQuestion();
                     });
                 });
+                nav.hide();
             } else {
-                $('<button class="gm-yes">Yes</button>').appendTo(optionsEl).on('click',function(e){
-                    e.preventDefault();
-                    if(q.add) q.add.forEach(s=>selected.add(s));
-                    if(q.follow){
-                        questions.splice(qIndex+1,0,followQuestions[q.follow]);
-                    }
-                    qIndex++; showQuestion();
+                ['Yes','No'].forEach(ans=>{
+                    const label=$('<label class="gm-pill"></label>');
+                    const input=$('<input type="radio">').val(ans);
+                    const span=$('<span></span>').text(ans);
+                    label.append(input,span).appendTo(optionsEl).on('click',function(e){
+                        e.preventDefault();
+                        if(ans==='Yes'){
+                            if(q.add) q.add.forEach(s=>selected.add(s));
+                            if(q.follow) questions.splice(qIndex+1,0,followQuestions[q.follow]);
+                        }
+                        qIndex++; showQuestion();
+                    });
                 });
-                $('<button class="gm-no">No</button>').appendTo(optionsEl).on('click',function(e){
-                    e.preventDefault();
-                    qIndex++; showQuestion();
-                });
+                nav.hide();
             }
         }
         showQuestion();
@@ -167,6 +177,7 @@
             selected.clear();
             locs = 1; pages = 50;
             results.hide();
+            progressBar.css('width','0%');
             if(this.value==='manual'){
                 quiz.hide();
                 manual.show();
@@ -184,11 +195,12 @@
             const form = manual.find('.gm-service-list');
             form.empty();
             for(let key in services){
-                const svc=services[key];
-                const row=$('<label class="gm-service-item"></label>').text(' '+svc.name);
-                const chk=$('<input type="checkbox">').attr('value',key);
-                row.prepend(chk);
-                form.append(row);
+                const svc = services[key];
+                const label = $('<label class="gm-pill gm-service-item"></label>');
+                const chk = $('<input type="checkbox">').val(key);
+                const span = $('<span></span>').text(svc.name);
+                label.append(chk, span);
+                form.append(label);
             }
         }
 
@@ -197,7 +209,10 @@
             questionEl.text(fq.text);
             optionsEl.empty();
             fq.options.forEach(opt=>{
-                $('<button class="gm-choice"></button>').text(opt.t).appendTo(optionsEl).on('click',function(e){
+                const label=$('<label class="gm-pill"></label>');
+                const input=$('<input type="radio">').val(opt.v);
+                const span=$('<span></span>').text(opt.t);
+                label.append(input,span).appendTo(optionsEl).on('click',function(e){
                     e.preventDefault();
                     if(fq.key==='locs') locs=opt.v;
                     if(fq.key==='pages') pages=opt.v;
@@ -207,6 +222,7 @@
             quiz.show();
             manual.hide();
             inputs.hide();
+            nav.hide();
         }
 
         manual.find('.gm-manual-next').on('click', function(e){
@@ -257,6 +273,7 @@
                     list.append('<li>'+k+': $'+res.breakdown[i][k].toFixed(0)+'</li>');
                 }
                 month.append(list);
+                month.on('click', function(){ $(this).toggleClass('open'); });
             });
             results.find('.gm-table').empty().append(wrap);
         });

--- a/grey-mirror-pricing-widget/widget.js
+++ b/grey-mirror-pricing-widget/widget.js
@@ -13,15 +13,28 @@
         'prompt': {name:'Prompt & Model Feedback', pillar:'ai', dep:[], discountable:true, loc:false, base:[250,250,0], monthly:300}
     };
 
-    const questions = [
-        {text:'Do you want your practice to be the very first thing patients see on Google Maps and in near-me searches?', add:['gbp_opt','cit_base','cit_plus']},
-        {text:'Is your website outdated or failing to turn visitors into patients?', add:['web_dev']},
+    const baseQuestions = [
+        {id:'local', text:'Do you want your practice to be the very first thing patients see on Google Maps and in near-me searches?', add:['gbp_opt','cit_base','cit_plus'], follow:'locations'},
+        {id:'web', text:'Is your website outdated or failing to turn visitors into patients?', add:['web_dev'], follow:'pages'},
         {text:'Do you need to boost your site\'s authority with quality backlinks?', add:['backlink']},
         {text:'Are you struggling to consistently get fresh 5-star patient reviews?', add:['review']},
         {text:'Would you go the extra mile by calling patients to get feedback and reviews?', add:['calls']},
         {text:'Do you want to build buzz in local online communities around your practice?', add:['community']},
         {text:'Do you want your practice to be visible in AI-driven search results and voice assistants?', add:['entity','answers','prompt']}
     ];
+
+    const followQuestions = {
+        locations:{type:'options',key:'locs', text:'How many physical locations do you have?', options:[
+            {t:'1-2 locations', v:2},
+            {t:'3-4 locations', v:4},
+            {t:'4+ locations', v:5}
+        ]},
+        pages:{type:'options',key:'pages', text:'What size do you want your new website to be?', options:[
+            {t:'Small (\u226450 pages)', v:50},
+            {t:'Medium (51-100 pages)', v:100},
+            {t:'Large (101-150 pages)', v:150}
+        ]}
+    };
 
     function enforceDeps(selected){
         if(selected.has('cit_plus')) selected.add('cit_base');
@@ -103,8 +116,12 @@
         const inputs = root.find('.gm-inputs');
         const results = root.find('.gm-results');
         const questionEl = quiz.find('.gm-question');
+        const optionsEl = quiz.find('.gm-options');
+        let questions = baseQuestions.slice();
         const selected = new Set();
         let qIndex = 0;
+        let locs = 1;
+        let pages = 50;
 
         function showQuestion(){
             if(qIndex>=questions.length){
@@ -112,35 +129,50 @@
                 inputs.show();
                 return;
             }
-            questionEl.text(questions[qIndex].text);
+            const q = questions[qIndex];
+            questionEl.text(q.text);
+            optionsEl.empty();
+            if(q.type==='options'){
+                q.options.forEach(opt=>{
+                    $('<button class="gm-choice"></button>').text(opt.t).appendTo(optionsEl).on('click',function(e){
+                        e.preventDefault();
+                        if(q.key==='locs') locs=opt.v;
+                        if(q.key==='pages') pages=opt.v;
+                        qIndex++; showQuestion();
+                    });
+                });
+            } else {
+                $('<button class="gm-yes">Yes</button>').appendTo(optionsEl).on('click',function(e){
+                    e.preventDefault();
+                    if(q.add) q.add.forEach(s=>selected.add(s));
+                    if(q.follow){
+                        questions.splice(qIndex+1,0,followQuestions[q.follow]);
+                    }
+                    qIndex++; showQuestion();
+                });
+                $('<button class="gm-no">No</button>').appendTo(optionsEl).on('click',function(e){
+                    e.preventDefault();
+                    qIndex++; showQuestion();
+                });
+            }
         }
         showQuestion();
 
-        quiz.find('.gm-yes').on('click', function(e){
-            e.preventDefault();
-            questions[qIndex].add.forEach(s=>selected.add(s));
-            qIndex++;
-            showQuestion();
-        });
-        quiz.find('.gm-no').on('click', function(e){
-            e.preventDefault();
-            qIndex++;
-            showQuestion();
-        });
-
         root.find('input[name="gm_flow"]').on('change', function(){
+            questions = baseQuestions.slice();
+            qIndex = 0;
+            selected.clear();
+            locs = 1; pages = 50;
+            results.hide();
             if(this.value==='manual'){
                 quiz.hide();
                 manual.show();
                 inputs.hide();
-                results.hide();
                 buildManual();
             } else {
                 quiz.show();
                 manual.hide();
                 inputs.hide();
-                results.hide();
-                qIndex=0; selected.clear();
                 showQuestion();
             }
         });
@@ -157,6 +189,23 @@
             }
         }
 
+        function askFollow(q, callback){
+            const fq = followQuestions[q];
+            questionEl.text(fq.text);
+            optionsEl.empty();
+            fq.options.forEach(opt=>{
+                $('<button class="gm-choice"></button>').text(opt.t).appendTo(optionsEl).on('click',function(e){
+                    e.preventDefault();
+                    if(fq.key==='locs') locs=opt.v;
+                    if(fq.key==='pages') pages=opt.v;
+                    callback();
+                });
+            });
+            quiz.show();
+            manual.hide();
+            inputs.hide();
+        }
+
         manual.find('.gm-manual-next').on('click', function(e){
             e.preventDefault();
             selected.clear();
@@ -164,35 +213,49 @@
                 selected.add(this.value);
             });
             enforceDeps(selected);
-            inputs.show();
+
+            const needLoc = Array.from(selected).some(s=>services[s].loc);
+            const needPages = selected.has('web_dev');
+
+            function showInputs(){
+                inputs.show();
+                quiz.hide();
+            }
+
+            if(needLoc){
+                askFollow('locations', function(){
+                    if(needPages){
+                        askFollow('pages', showInputs);
+                    } else {
+                        showInputs();
+                    }
+                });
+            } else if(needPages){
+                askFollow('pages', showInputs);
+            } else {
+                showInputs();
+            }
         });
 
         root.find('.gm-calc').on('click', function(e){
             e.preventDefault();
-            const locs = parseInt($('#gm-locations').val())||1;
-            const pages = parseInt($('#gm-pages').val())||50;
             const discount = $('#gm-discount').val();
             enforceDeps(selected);
             const res = calcPrices(selected, locs, pages, discount);
             const summary = summaryText(selected);
             results.show();
             results.find('.gm-summary').text('Summary: '+summary);
-            const table = $('<table></table>');
-            const header = $('<tr><th>Month</th><th>Total</th></tr>');
-            table.append(header);
+            const wrap = $('<div class="gm-months"></div>');
             ['1','2','3','4+'].forEach((m,i)=>{
-                const row=$('<tr></tr>');
-                row.append('<td>Month '+m+'</td>');
-                row.append('<td>$'+res.months[i].toFixed(0)+'</td>');
-                const breakdown = res.breakdown[i];
-                const details=$('<ul></ul>');
-                for(let k in breakdown){
-                    details.append('<li>'+k+': $'+breakdown[k].toFixed(0)+'</li>');
+                const month = $('<div class="gm-month"></div>').append('<div class="gm-total">$'+res.months[i].toFixed(0)+'</div>').appendTo(wrap);
+                month.prepend('<div class="gm-label">Month '+m+'</div>');
+                const list=$('<ul class="gm-month-details"></ul>');
+                for(let k in res.breakdown[i]){
+                    list.append('<li>'+k+': $'+res.breakdown[i][k].toFixed(0)+'</li>');
                 }
-                row.append($('<td></td>').append(details));
-                table.append(row);
+                month.append(list);
             });
-            results.find('.gm-table').empty().append(table);
+            results.find('.gm-table').empty().append(wrap);
         });
     });
 })(jQuery);

--- a/grey-mirror-pricing-widget/widget.php
+++ b/grey-mirror-pricing-widget/widget.php
@@ -35,17 +35,14 @@ class GM_Pricing_Widget extends Widget_Base {
             </div>
             <div class="gm-quiz" style="display:block">
                 <div class="gm-question"></div>
-                <button class="gm-yes">Yes</button>
-                <button class="gm-no">No</button>
+                <div class="gm-options"></div>
             </div>
             <div class="gm-manual" style="display:none">
                 <form class="gm-service-list"></form>
                 <button class="gm-manual-next">Next</button>
             </div>
             <div class="gm-inputs" style="display:none">
-                <label>Locations: <input type="number" id="gm-locations" min="1" value="1"></label>
-                <label>Website pages: <input type="number" id="gm-pages" min="1" value="50"></label>
-                <label>Discount: 
+                <label>Discount:
                     <select id="gm-discount">
                         <option value="none">No Discount</option>
                         <option value="super">Super-Duper Discount</option>

--- a/grey-mirror-pricing-widget/widget.php
+++ b/grey-mirror-pricing-widget/widget.php
@@ -28,33 +28,41 @@ class GM_Pricing_Widget extends Widget_Base {
 
     protected function render() {
         ?>
-        <div id="gm-pricing-calculator" class="gm-widget">
-            <div class="gm-flow-select">
-                <label><input type="radio" name="gm_flow" value="quiz" checked> Help Me Choose</label>
-                <label><input type="radio" name="gm_flow" value="manual"> I Know What I Want</label>
-            </div>
-            <div class="gm-quiz" style="display:block">
-                <div class="gm-question"></div>
-                <div class="gm-options"></div>
-            </div>
-            <div class="gm-manual" style="display:none">
-                <form class="gm-service-list"></form>
-                <button class="gm-manual-next">Next</button>
-            </div>
-            <div class="gm-inputs" style="display:none">
-                <label>Discount:
-                    <select id="gm-discount">
-                        <option value="none">No Discount</option>
-                        <option value="super">Super-Duper Discount</option>
-                        <option value="dirt">I have dirt on the founders</option>
-                        <option value="reverse">Founders have dirt on me (Reverse)</option>
-                    </select>
-                </label>
-                <button class="gm-calc">Calculate Pricing</button>
-            </div>
-            <div class="gm-results" style="display:none">
-                <div class="gm-summary"></div>
-                <div class="gm-table"></div>
+        <div class="gm-wrapper">
+            <div id="gm-pricing-calculator" class="gm-card">
+                <div class="gm-progress"><div class="gm-progress-bar"></div></div>
+                <div class="gm-flow-select">
+                    <label><input type="radio" name="gm_flow" value="quiz" checked> Help Me Choose</label>
+                    <label><input type="radio" name="gm_flow" value="manual"> I Know What I Want</label>
+                </div>
+                <div class="gm-quiz" style="display:block">
+                    <div class="gm-question"></div>
+                    <div class="gm-options"></div>
+                    <div class="gm-nav" style="display:none">
+                        <button class="gm-back" type="button">Back</button>
+                        <button class="gm-next" type="button">Next <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M5 12h14M13 5l7 7-7 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                    </div>
+                </div>
+                <div class="gm-manual" style="display:none">
+                    <form class="gm-service-list"></form>
+                    <button class="gm-manual-next gm-next">Next <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M5 12h14M13 5l7 7-7 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                </div>
+                <div class="gm-inputs" style="display:none">
+                    <label>Discount:
+                        <select id="gm-discount">
+                            <option value="none">No Discount</option>
+                            <option value="super">Super-Duper Discount</option>
+                            <option value="dirt">I have dirt on the founders</option>
+                            <option value="reverse">Founders have dirt on me (Reverse)</option>
+                        </select>
+                    </label>
+                    <button class="gm-calc gm-next">See Pricing <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M5 12h14M13 5l7 7-7 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
+                </div>
+                <div class="gm-results" style="display:none">
+                    <div class="gm-summary"></div>
+                    <div class="gm-table"></div>
+                    <button class="gm-cta">Lock My Plan</button>
+                </div>
             </div>
         </div>
         <?php

--- a/grey-mirror-pricing-widget/widget.php
+++ b/grey-mirror-pricing-widget/widget.php
@@ -32,8 +32,8 @@ class GM_Pricing_Widget extends Widget_Base {
             <div id="gm-pricing-calculator" class="gm-card">
                 <div class="gm-progress"><div class="gm-progress-bar"></div></div>
                 <div class="gm-flow-select">
-                    <label><input type="radio" name="gm_flow" value="quiz" checked> Help Me Choose</label>
-                    <label><input type="radio" name="gm_flow" value="manual"> I Know What I Want</label>
+                    <label class="gm-pill"><input type="radio" name="gm_flow" value="quiz" checked><span>Help Me Choose</span></label>
+                    <label class="gm-pill"><input type="radio" name="gm_flow" value="manual"><span>I Know What I Want</span></label>
                 </div>
                 <div class="gm-quiz" style="display:block">
                     <div class="gm-question"></div>
@@ -48,7 +48,8 @@ class GM_Pricing_Widget extends Widget_Base {
                     <button class="gm-manual-next gm-next">Next <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M5 12h14M13 5l7 7-7 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg></button>
                 </div>
                 <div class="gm-inputs" style="display:none">
-                    <label>Discount:
+                    <div class="gm-question">Discount:</div>
+                    <label class="gm-select">
                         <select id="gm-discount">
                             <option value="none">No Discount</option>
                             <option value="super">Super-Duper Discount</option>

--- a/grey-mirror-pricing-widget/widget.php
+++ b/grey-mirror-pricing-widget/widget.php
@@ -1,0 +1,65 @@
+<?php
+use Elementor\Widget_Base;
+use Elementor\Controls_Manager;
+use Elementor\Repeater;
+
+if (!defined('ABSPATH')) exit;
+
+class GM_Pricing_Widget extends Widget_Base {
+    public function get_name() {
+        return 'gm_pricing_calculator';
+    }
+
+    public function get_title() {
+        return 'Grey Mirror Pricing Calculator';
+    }
+
+    public function get_icon() {
+        return 'eicon-calculator';
+    }
+
+    public function get_categories() {
+        return ['general'];
+    }
+
+    protected function register_controls() {
+        // no controls needed
+    }
+
+    protected function render() {
+        ?>
+        <div id="gm-pricing-calculator" class="gm-widget">
+            <div class="gm-flow-select">
+                <label><input type="radio" name="gm_flow" value="quiz" checked> Help Me Choose</label>
+                <label><input type="radio" name="gm_flow" value="manual"> I Know What I Want</label>
+            </div>
+            <div class="gm-quiz" style="display:block">
+                <div class="gm-question"></div>
+                <button class="gm-yes">Yes</button>
+                <button class="gm-no">No</button>
+            </div>
+            <div class="gm-manual" style="display:none">
+                <form class="gm-service-list"></form>
+                <button class="gm-manual-next">Next</button>
+            </div>
+            <div class="gm-inputs" style="display:none">
+                <label>Locations: <input type="number" id="gm-locations" min="1" value="1"></label>
+                <label>Website pages: <input type="number" id="gm-pages" min="1" value="50"></label>
+                <label>Discount: 
+                    <select id="gm-discount">
+                        <option value="none">No Discount</option>
+                        <option value="super">Super-Duper Discount</option>
+                        <option value="dirt">I have dirt on the founders</option>
+                        <option value="reverse">Founders have dirt on me (Reverse)</option>
+                    </select>
+                </label>
+                <button class="gm-calc">Calculate Pricing</button>
+            </div>
+            <div class="gm-results" style="display:none">
+                <div class="gm-summary"></div>
+                <div class="gm-table"></div>
+            </div>
+        </div>
+        <?php
+    }
+}


### PR DESCRIPTION
## Summary
- implement Grey Mirror Pricing Calculator plugin
- add Elementor widget registration
- create basic widget markup and logic
- provide JavaScript for quiz/manual flows, dependencies, discounts, and pricing calculations

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68422090ad288320af23ce186417c17c