### PR TITLE
Add Grey Mirror Service-Match Quiz plugin

### DIFF
--- a/gm-service-match-quiz/gm-elementor-widget.php
+++ b/gm-service-match-quiz/gm-elementor-widget.php
@@ -1,0 +1,66 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class GM_Quiz_Elementor_Widget extends \Elementor\Widget_Base {
+    public function get_name() {
+        return 'gm_quiz';
+    }
+
+    public function get_title() {
+        return __( 'Service Match Quiz', 'gm-quiz' );
+    }
+
+    public function get_icon() {
+        return 'eicon-question';
+    }
+
+    public function get_categories() {
+        return [ 'general' ];
+    }
+
+    public function get_style_depends() {
+        return [ 'gm-quiz' ];
+    }
+
+    public function get_script_depends() {
+        return [ 'gm-quiz' ];
+    }
+
+    protected function register_controls() {
+        $this->start_controls_section( 'content_section', [
+            'label' => __( 'Content', 'gm-quiz' ),
+        ] );
+
+        $this->add_control( 'heading', [
+            'label' => __( 'Heading', 'gm-quiz' ),
+            'type' => \Elementor\Controls_Manager::TEXTAREA,
+            'default' => __( 'We have 2 047 unique service plans.<br>Let’s find the one that fits your practice.', 'gm-quiz' ),
+        ] );
+
+        $this->add_control( 'start_text', [
+            'label' => __( 'Start Button Text', 'gm-quiz' ),
+            'type' => \Elementor\Controls_Manager::TEXT,
+            'default' => __( 'Start 30-second Quiz →', 'gm-quiz' ),
+        ] );
+
+        $this->add_control( 'accent_color', [
+            'label' => __( 'Accent Color', 'gm-quiz' ),
+            'type' => \Elementor\Controls_Manager::COLOR,
+            'default' => '#0d90ff',
+        ] );
+
+        $this->end_controls_section();
+    }
+
+    protected function render() {
+        $settings = $this->get_settings_for_display();
+        echo do_shortcode( sprintf(
+            '[gm_quiz heading="%s" start_text="%s" accent_color="%s"]',
+            esc_attr( $settings['heading'] ),
+            esc_attr( $settings['start_text'] ),
+            esc_attr( $settings['accent_color'] )
+        ) );
+    }
+}

--- a/gm-service-match-quiz/gm-quiz.css
+++ b/gm-service-match-quiz/gm-quiz.css
@@ -1,0 +1,27 @@
+:root{
+  --accent:#0d90ff;
+  --glass-bg:rgba(255,255,255,.18);
+  --glass-blur:blur(18px);
+  --radius:24px;
+  --shadow:0 8px 24px rgba(0,0,0,.15);
+  --font-sans:SF Pro,-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+}
+
+.gm-quiz{font-family:var(--font-sans);}
+.hero-wrap{display:flex;gap:4rem;align-items:center;}
+@media (max-width:1023px){.hero-wrap{flex-direction:column-reverse;}}
+
+.gm-quiz__card{max-width:420px;width:100%;background:var(--glass-bg);backdrop-filter:var(--glass-blur);border-radius:var(--radius);box-shadow:var(--shadow);padding:2rem 2.25rem;position:relative;isolation:isolate;}
+
+.gm-quiz__progress{height:4px;background:rgba(0,0,0,.1);border-radius:2px;overflow:hidden;margin-bottom:1rem;}
+.gm-quiz__bar{height:100%;width:0;background:var(--accent);transition:width .3s ease;}
+
+.gm-quiz__primary{background:var(--accent);color:#fff;border:none;border-radius:var(--radius);padding:.5rem 1rem;cursor:pointer;font-size:1rem;}
+.gm-quiz__primary:focus{outline:none;box-shadow:0 0 0 3px rgba(13,144,255,.4);}
+
+.gm-quiz__question p{margin-bottom:.5rem;font-weight:600;}
+.gm-quiz__question label{margin-right:1rem;}
+
+.gm-quiz__pillar{display:block;width:100%;text-align:left;margin-bottom:.5rem;border:1px solid var(--accent);border-radius:var(--radius);padding:.5rem;cursor:pointer;background:transparent;}
+.gm-quiz__pillar ul{margin-top:.5rem;padding-left:1.2rem;list-style:disc;}
+

--- a/gm-service-match-quiz/gm-quiz.js
+++ b/gm-service-match-quiz/gm-quiz.js
@@ -1,0 +1,109 @@
+(function(){
+  const cfg = window.gmQuizData || {};
+  const wrap = document.querySelector('.gm-quiz');
+  if(!wrap) return;
+  const bar = wrap.querySelector('.gm-quiz__bar');
+  const intro = wrap.querySelector('.gm-quiz__intro');
+  const result = wrap.querySelector('.gm-quiz__result');
+  const pillarsBox = result.querySelector('.gm-quiz__pillars');
+  const form = result.querySelector('.gm-quiz__email');
+
+  const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  let step = 0;
+  const answers = {};
+  const triggeredSubs = new Set();
+
+  function createQuestion(q){
+    const s = document.createElement('section');
+    s.className='gm-quiz__question';
+    s.dataset.step=q.id;
+    s.innerHTML=`<p>${q.text}</p>
+      <label><input type="radio" name="${q.id}" value="yes">Yes</label>
+      <label><input type="radio" name="${q.id}" value="no" checked>No</label>
+      <button class="gm-quiz__primary">Next</button>`;
+    s.hidden=true;
+    s.querySelector('button').addEventListener('click',()=>next(s,q));
+    result.before(s);
+  }
+
+  function showSection(sec){
+    wrap.querySelectorAll('section[data-step]').forEach(el=>el.hidden=true);
+    if(sec){
+      sec.hidden=false;
+      if(!reduce){
+        sec.style.opacity=0;
+        sec.style.transform='translateY(10px)';
+        requestAnimationFrame(()=>{
+          sec.style.transition='opacity .15s,transform .15s';
+          sec.style.opacity=1;sec.style.transform='translateY(0)';
+        });
+      }
+    }
+  }
+
+  function next(section,q){
+    const val=section.querySelector('input:checked').value;
+    answers[q.id]=val==='yes';
+    if(answers[q.id]) q.subs.forEach(s=>triggeredSubs.add(s));
+    step++;
+    bar.style.width=(step/cfg.questions.length)*100+'%';
+    if(step>cfg.questions.length){
+      computeResults();
+    }else{
+      const nxt=wrap.querySelector(`section[data-step="${cfg.questions[step-1].id}"]`);
+      showSection(nxt);
+    }
+  }
+
+  function computeResults(){
+    const pillarIds=[...new Set([...triggeredSubs].map(s=>cfg.subToPillar[s]))];
+    pillarIds.forEach(pid=>{
+      const p=cfg.pillars[pid];
+      const btn=document.createElement('button');
+      btn.className='gm-quiz__pillar';
+      btn.setAttribute('aria-expanded','false');
+      btn.innerHTML=`<a href="${p.url}" target="_blank">${p.name}</a>`;
+      const list=document.createElement('ul');
+      p.services.forEach(s=>{
+        if(triggeredSubs.has(s)){
+          const li=document.createElement('li');
+          li.textContent=s;list.appendChild(li);
+        }
+      });
+      list.hidden=true;btn.appendChild(list);
+      btn.addEventListener('click',()=>{
+        const open=btn.getAttribute('aria-expanded')==='true';
+        btn.setAttribute('aria-expanded',!open);
+        list.hidden=open;
+      });
+      pillarsBox.appendChild(btn);
+    });
+    if(!pillarIds.length){
+      form.hidden=true;
+      result.querySelector('.gm-quiz__fallback').hidden=false;
+    }
+    showSection(result);
+  }
+
+  form.addEventListener('submit',async e=>{
+    e.preventDefault();
+    const email=form.querySelector('input[type=email]').value;
+    const body={email,answers,pillars:[...triggeredSubs]};
+    try{
+      await fetch(cfg.restUrl,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body)});
+      window.gtag&&gtag('event','quiz_complete',{yesCount:Object.values(answers).filter(Boolean).length,pillars:[...triggeredSubs]});
+      form.hidden=true;result.querySelector('.gm-quiz__thanks').hidden=false;
+    }catch(err){
+      form.hidden=true;result.querySelector('.gm-quiz__thanks').hidden=false;
+    }
+  });
+
+  intro.querySelector('[data-step="start"]').addEventListener('click',()=>{
+    step=1;intro.hidden=true;
+    const sec=wrap.querySelector(`section[data-step="${cfg.questions[0].id}"]`);
+    showSection(sec);
+  });
+
+  cfg.questions.forEach(createQuestion);
+})();

--- a/gm-service-match-quiz/gm-quiz.php
+++ b/gm-service-match-quiz/gm-quiz.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Grey Mirror Service-Match Quiz
  * Description: Shortcode quiz to match services.
- * Version: 0.4.0
+ * Version: 0.4.1
  * Author: Grey Mirror Digital
  * Text Domain: gm-quiz
  */
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
-define( 'GM_QUIZ_VERSION', '0.4.0' );
+define( 'GM_QUIZ_VERSION', '0.4.1' );
 
 define( 'GM_QUIZ_DIR', plugin_dir_path( __FILE__ ) );
 
@@ -76,16 +76,22 @@ function gm_quiz_assets() {
 }
 add_action( 'wp_enqueue_scripts', 'gm_quiz_assets' );
 
-function gm_quiz_shortcode() {
+function gm_quiz_shortcode( $atts = [] ) {
+    $atts = shortcode_atts([
+        'heading' => 'We have 2 047 unique service plans.<br>Let’s find the one that fits your practice.',
+        'start_text' => 'Start 30-second Quiz →',
+        'accent_color' => '',
+    ], $atts, 'gm_quiz' );
+    $style = $atts['accent_color'] ? ' style="--accent:' . esc_attr( $atts['accent_color'] ) . ';"' : '';
     ob_start();
     ?>
-<div class="gm-quiz">
+<div class="gm-quiz"<?php echo $style; ?>>
   <div class="gm-quiz__card" part="card">
     <div class="gm-quiz__progress"><div class="gm-quiz__bar"></div></div>
 
     <section class="gm-quiz__intro">
-      <h2>We have 2 047 unique service plans.<br>Let’s find the one that fits your practice.</h2>
-      <button class="gm-quiz__primary" data-step="start">Start 30-second Quiz →</button>
+      <h2><?php echo wp_kses_post( $atts['heading'] ); ?></h2>
+      <button class="gm-quiz__primary" data-step="start"><?php echo esc_html( $atts['start_text'] ); ?></button>
     </section>
 
     <section class="gm-quiz__result" hidden>
@@ -139,3 +145,12 @@ function gm_quiz_ajax_email() {
     wp_mail( $to, $subject, $message );
     wp_send_json_success();
 }
+
+function gm_quiz_register_elementor_widget( $widgets_manager ) {
+    if ( ! class_exists( '\\Elementor\\Widget_Base' ) ) {
+        return;
+    }
+    require_once GM_QUIZ_DIR . 'gm-elementor-widget.php';
+    $widgets_manager->register( new GM_Quiz_Elementor_Widget() );
+}
+add_action( 'elementor/widgets/register', 'gm_quiz_register_elementor_widget' );

--- a/gm-service-match-quiz/gm-quiz.php
+++ b/gm-service-match-quiz/gm-quiz.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Plugin Name: Grey Mirror Service-Match Quiz
+ * Description: Shortcode quiz to match services.
+ * Version: 0.4.0
+ * Author: Grey Mirror Digital
+ * Text Domain: gm-quiz
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+define( 'GM_QUIZ_VERSION', '0.4.0' );
+
+define( 'GM_QUIZ_DIR', plugin_dir_path( __FILE__ ) );
+
+function gm_quiz_assets() {
+    wp_enqueue_style( 'gm-quiz', plugins_url( 'gm-quiz.css', __FILE__ ), [], GM_QUIZ_VERSION );
+    wp_enqueue_script( 'gm-quiz', plugins_url( 'gm-quiz.js', __FILE__ ), [], GM_QUIZ_VERSION, true );
+
+    $questions = [
+        ['id' => 'q1', 'text' => 'Do you want to be the first practice patients see when they Google “your specialty near me”?', 'subs' => ['S1', 'S2', 'S3']],
+        ['id' => 'q2', 'text' => 'Does your website feel dated or struggle to turn visitors into booked patients?', 'subs' => ['S4']],
+        ['id' => 'q3', 'text' => 'Do you want your site to appear ahead of competitors in Google searches?', 'subs' => ['S5']],
+        ['id' => 'q4', 'text' => 'Is your stream of five-star reviews falling short of your competitors?', 'subs' => ['S6']],
+        ['id' => 'q5', 'text' => 'Are you interested in making patients feel valued—and preventing bad reviews—with a personalized follow-up call?', 'subs' => ['S7']],
+        ['id' => 'q6', 'text' => 'Do you want more buzz about your practice in the online groups patients trust?', 'subs' => ['S8']],
+        ['id' => 'q7', 'text' => 'Should AI tools like ChatGPT recommend your clinic as the top provider?', 'subs' => ['S9', 'S10', 'S11']],
+    ];
+
+    $sub_to_pillar = [
+        'S1' => 'LPO',
+        'S2' => 'LPO',
+        'S3' => 'LPO',
+        'S4' => 'WSA',
+        'S5' => 'WSA',
+        'S6' => 'CRE',
+        'S7' => 'CRE',
+        'S8' => 'CRE',
+        'S9' => 'ASV',
+        'S10' => 'ASV',
+        'S11' => 'ASV',
+    ];
+
+    $pillars = [
+        'LPO' => [
+            'name' => 'Local Pack Optimization',
+            'url'  => 'https://greymirrordigital.com/marketing-solutions/local-pack-optimization/',
+            'services' => ['S1', 'S2', 'S3'],
+        ],
+        'WSA' => [
+            'name' => 'Website & Search Authority',
+            'url'  => 'https://greymirrordigital.com/marketing-solutions/website-and-search-authority/',
+            'services' => ['S4', 'S5'],
+        ],
+        'CRE' => [
+            'name' => 'Conversion & Reputation Engine',
+            'url'  => 'https://greymirrordigital.com/marketing-solutions/conversion-and-reputation-engine/',
+            'services' => ['S6', 'S7', 'S8'],
+        ],
+        'ASV' => [
+            'name' => 'AI Search Visibility',
+            'url'  => 'https://greymirrordigital.com/marketing-solutions/ai-search-visibility/',
+            'services' => ['S9', 'S10', 'S11'],
+        ],
+    ];
+
+    wp_localize_script( 'gm-quiz', 'gmQuizData', [
+        'questions' => $questions,
+        'subToPillar' => $sub_to_pillar,
+        'pillars' => $pillars,
+        'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+        'restUrl' => esc_url_raw( rest_url( 'gm/v1/lead' ) ),
+    ] );
+}
+add_action( 'wp_enqueue_scripts', 'gm_quiz_assets' );
+
+function gm_quiz_shortcode() {
+    ob_start();
+    ?>
+<div class="gm-quiz">
+  <div class="gm-quiz__card" part="card">
+    <div class="gm-quiz__progress"><div class="gm-quiz__bar"></div></div>
+
+    <section class="gm-quiz__intro">
+      <h2>We have 2 047 unique service plans.<br>Let’s find the one that fits your practice.</h2>
+      <button class="gm-quiz__primary" data-step="start">Start 30-second Quiz →</button>
+    </section>
+
+    <section class="gm-quiz__result" hidden>
+      <h3>Your best-fit services</h3>
+      <div class="gm-quiz__pillars"></div>
+
+      <form class="gm-quiz__email">
+        <label>Enter your email for a custom price estimate</label>
+        <input type="email" required placeholder="you@example.com" />
+        <button class="gm-quiz__primary">Send my Price Estimate →</button>
+      </form>
+
+      <p class="gm-quiz__thanks" hidden>Thanks! Check your inbox.</p>
+      <p class="gm-quiz__fallback" hidden>Looks like you’re already dialed in! <a href="https://greymirrordigital.com/contact/">Contact us</a> for a second opinion.</p>
+    </section>
+  </div>
+</div>
+<?php
+    return ob_get_clean();
+}
+add_shortcode( 'gm_quiz', 'gm_quiz_shortcode' );
+
+function gm_quiz_register_routes() {
+    register_rest_route( 'gm/v1', '/lead', [
+        'methods' => 'POST',
+        'callback' => 'gm_quiz_handle_lead',
+        'permission_callback' => '__return_true',
+    ] );
+}
+add_action( 'rest_api_init', 'gm_quiz_register_routes' );
+
+function gm_quiz_handle_lead( WP_REST_Request $request ) {
+    $data  = $request->get_json_params();
+    $email = isset( $data['email'] ) ? sanitize_email( $data['email'] ) : '';
+    $to     = 'Jake@greymirrordigital.com';
+    $subject = 'New Quiz Lead';
+    $message = "Email: {$email}\n\n" . print_r( $data, true );
+    wp_mail( $to, $subject, $message );
+
+    return [ 'success' => true ];
+}
+
+add_action( 'wp_ajax_gm_quiz_email', 'gm_quiz_ajax_email' );
+add_action( 'wp_ajax_nopriv_gm_quiz_email', 'gm_quiz_ajax_email' );
+function gm_quiz_ajax_email() {
+    $email = isset( $_POST['email'] ) ? sanitize_email( wp_unslash( $_POST['email'] ) ) : '';
+    $data  = isset( $_POST['data'] ) ? wp_unslash( $_POST['data'] ) : '';
+    $to     = 'Jake@greymirrordigital.com';
+    $subject = 'New Quiz Lead';
+    $message = "Email: {$email}\n\n{$data}";
+    wp_mail( $to, $subject, $message );
+    wp_send_json_success();
+}

--- a/gm-service-match-quiz/readme.txt
+++ b/gm-service-match-quiz/readme.txt
@@ -3,7 +3,7 @@ Contributors: greymirror
 Tags: quiz
 Requires at least: 6.0
 Tested up to: 6.5
-Stable tag: 0.4.0
+Stable tag: 0.4.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -16,5 +16,8 @@ A shortcode based quiz that matches visitors with the most relevant Grey Mirror 
 3. Place `[gm_quiz]` in any page or post.
 
 == Changelog ==
+= 0.4.1 =
+* Added Elementor widget with customizable heading, button text, and accent color.
+
 = 0.4.0 =
 * Initial release.

--- a/gm-service-match-quiz/readme.txt
+++ b/gm-service-match-quiz/readme.txt
@@ -1,0 +1,20 @@
+=== Grey Mirror Service-Match Quiz ===
+Contributors: greymirror
+Tags: quiz
+Requires at least: 6.0
+Tested up to: 6.5
+Stable tag: 0.4.0
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+== Description ==
+A shortcode based quiz that matches visitors with the most relevant Grey Mirror services. Use `[gm_quiz]` inside Elementor to show the interactive card.
+
+== Installation ==
+1. Upload the plugin folder to the `/wp-content/plugins/` directory.
+2. Activate the plugin through the Plugins menu in WordPress.
+3. Place `[gm_quiz]` in any page or post.
+
+== Changelog ==
+= 0.4.0 =
+* Initial release.


### PR DESCRIPTION
## Summary
- add `gm-service-match-quiz` plugin with shortcode `[gm_quiz]`
- include PHP, JS and CSS files for quiz logic and styling
- document basic plugin usage

## Testing
- `php` not available so syntax checks were skipped

------
https://chatgpt.com/codex/tasks/task_e_6844afb5dce48320b0f0331966342582